### PR TITLE
More descriptive exception including field name

### DIFF
--- a/lib/iso8583/field.rb
+++ b/lib/iso8583/field.rb
@@ -31,7 +31,7 @@ module ISO8583
 
       # make sure we have enough data ...
       if raw_value.length != len
-        mes = "Field has incorrect length! field: #{raw_value} len/expected: #{raw_value.length}/#{len}"
+        mes = "Field (#{name}) has incorrect length! field: #{raw_value} len/expected: #{raw_value.length}/#{len}"
         raise ISO8583ParseException.new(mes)
       end
 


### PR DESCRIPTION
@scalone in certain scenarios we might get the exception `Field has incorrect length` but it doesn't mention the invalid field. Perhaps this change would make it easier to figure it out? cc: @williamrgt 