### PR TITLE
Added ruby_executable_apps method

### DIFF
--- a/lib/da_funk/params_dat.rb
+++ b/lib/da_funk/params_dat.rb
@@ -209,6 +209,10 @@ module DaFunk
       end
     end
 
+    def self.ruby_executable_apps
+      self.apps.select(&:ruby?)
+    end
+
     def self.executable_apps
       self.apps.select{|app| app.label != "X"}
     end


### PR DESCRIPTION
Implemented ruby_executable_apps, this will replace executable_apps call on main pre_load_applications.