### PR TITLE
Menu image touchscreen

### DIFF
--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -145,6 +145,52 @@ module DaFunk
       end
     end
 
+    # Create a menu with touchscreen and keyboard selection support.
+    #
+    # @param path [String] file with path to be displayed
+    #
+    # @param menu_itens [Hash] Hash in this format:
+    # {
+    #   menu_item_index => {:x => range..range, :y => range..range},
+    #   menu_item_index => {:x => range..range, :y => range..range}
+    # }
+    #
+    # @param options [Hash] Hash containing options to change the menu behaviour.
+    #
+    # @example
+    #   options = {
+    #     # Input Timeout in miliseconds
+    #     :timeout => 30_000
+    #   }
+    #
+    #   menu_itens = {
+    #     1 => {:x => 0..225, :y => 10..98},
+    #     2 => {:x => 290..300, :y => 50..100}
+    #   }
+    #
+    #   menu_image_touchscreen_or_keyboard('image.bmp', menu_itens, options)
+    #
+    # @return menu_item_index selected will be returned
+    # @return if timeout nil will be returned
+    def menu_image_touchscreen_or_keyboard(path, menu_itens, options = {})
+      return nil if menu_itens.empty?
+
+      Device::Display.print_bitmap(path)
+
+      timeout = options[:timeout] || Device::IO.timeout
+      event, key = wait_touchscreen_or_keyboard_event(menu_itens, timeout)
+
+      if event == :keyboard
+        if key == Device::IO::CANCEL
+          options[:default]
+        else
+          menu_itens.keys[key.to_i-1]
+        end
+      elsif event == :touchscreen
+        menu_itens.keys[key.to_i]
+      end
+    end
+
     # Wait for touchscreen or keyboard event.
     #
     # @param menu_itens [Hash] Hash in this format:

--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -215,7 +215,7 @@ module DaFunk
     # @return array with event happened and key
     def wait_touchscreen_or_keyboard_event(menu_itens, timeout, options = {})
       time = Time.now + timeout / 1000
-      keys = ((1..(menu_itens.size)).to_a.map(&:to_s) + [Device::IO::CANCEL]).flatten
+      keys = ((1..(menu_itens.size)).to_a.map(&:to_s) + options[:special_keys]).flatten
 
       loop do
         break([:timeout, Device::IO::KEY_TIMEOUT]) if Time.now > time

--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -178,7 +178,8 @@ module DaFunk
       Device::Display.print_bitmap(path)
 
       timeout = options[:timeout] || Device::IO.timeout
-      event, key = wait_touchscreen_or_keyboard_event(menu_itens, timeout)
+      options[:special_keys] = [Device::IO::CANCEL]
+
       event, key = wait_touchscreen_or_keyboard_event(menu_itens, timeout, options)
 
       if event == :keyboard

--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -184,10 +184,11 @@ module DaFunk
         if key == Device::IO::CANCEL
           options[:default]
         else
-          menu_itens.keys[key.to_i-1]
+          index = key.to_i-1 == -1 ? 0 : key.to_i-1
+          menu_itens.keys[index]
         end
       elsif event == :touchscreen
-        menu_itens.keys[key.to_i]
+        menu_itens.select {|k, v| k == key}.shift[0]
       end
     end
 

--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -179,6 +179,7 @@ module DaFunk
 
       timeout = options[:timeout] || Device::IO.timeout
       event, key = wait_touchscreen_or_keyboard_event(menu_itens, timeout)
+      event, key = wait_touchscreen_or_keyboard_event(menu_itens, timeout, options)
 
       if event == :keyboard
         if key == Device::IO::CANCEL
@@ -212,7 +213,7 @@ module DaFunk
     #   wait_touchscreen_or_keyboard_event(menu_itens, 30_000)
     #
     # @return array with event happened and key
-    def wait_touchscreen_or_keyboard_event(menu_itens, timeout)
+    def wait_touchscreen_or_keyboard_event(menu_itens, timeout, options = {})
       time = Time.now + timeout / 1000
       keys = ((1..(menu_itens.size)).to_a.map(&:to_s) + [Device::IO::CANCEL]).flatten
 


### PR DESCRIPTION
- Added new method DaFunk::Helper#wait_touchscreen_or_keyboard_event.
  - This method can be used for a situation where we need to wait for an keyboard or touch screen event.

- Added new method DaFunk::Helper#menu_image_touchscreen_or_keyboard.
  - This method can be used for a situation where we need to show an image and we are waiting for a touch screen or keyboard event, and as result we get the menu index.
