### PR TITLE
Use getxy instead getxy_stream to clean up events queue.

### DIFF
--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -220,7 +220,7 @@ module DaFunk
 
       loop do
         break([:timeout, Device::IO::KEY_TIMEOUT]) if Time.now > time
-        x, y = getxy_stream(100)
+        x, y = getxy(100)
         if x && y
           event = parse_touchscreen_event(menu_itens, x, y)
           break(event) if event


### PR DESCRIPTION
getxy_stream does not clean up the events queue, so this cause a touch screen event without actually an event on the screen, so we use getxy to avoid it.