### PR TITLE
Load/update config.dat file before set payment channel attempts

### DIFF
--- a/lib/device/setting.rb
+++ b/lib/device/setting.rb
@@ -134,6 +134,7 @@ class Device
 
     # helper
     def self.payment_channel_set_attempts(time = nil, attempts = nil)
+      setup
       if time
         str = "%d-%02d-%02d"
         update_attributes({


### PR DESCRIPTION
If a thread change the config file this implementation will avoid
another thread to change it again.