### PR TITLE
Moved responsability of beep sound for touch event to another method.

### DIFF
--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -443,7 +443,7 @@ module DaFunk
     def parse_touchscreen_event(menu_itens, x, y)
       menu_itens.each do |key, value|
         if value[:x].include?(x) && value[:y].include?(y)
-          PAX::Audio.beep(7, 60)
+          Device::Audio.beep(7, 60)
           return([:touchscreen, key])
         end
       end

--- a/lib/da_funk/helper.rb
+++ b/lib/da_funk/helper.rb
@@ -190,7 +190,6 @@ module DaFunk
           menu_itens.keys[index]
         end
       elsif event == :touchscreen
-        PAX::Audio.beep(7, 60)
         menu_itens.select {|k, v| k == key}.shift[0]
       end
     end
@@ -444,6 +443,7 @@ module DaFunk
     def parse_touchscreen_event(menu_itens, x, y)
       menu_itens.each do |key, value|
         if value[:x].include?(x) && value[:y].include?(y)
+          PAX::Audio.beep(7, 60)
           return([:touchscreen, key])
         end
       end


### PR DESCRIPTION
DaFunk::Helper#parse_touchscreen_event is responsable for it now.